### PR TITLE
Reuse webview instance from discord branch

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -1,0 +1,373 @@
+package com.reactnativecommunity.webview;
+
+
+import android.annotation.SuppressLint;
+import android.os.Build;
+import android.text.TextUtils;
+import android.view.MotionEvent;
+import android.view.ViewGroup;
+import android.webkit.JavascriptInterface;
+import android.webkit.WebChromeClient;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import android.widget.FrameLayout;
+
+import androidx.annotation.Nullable;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.CatalystInstance;
+import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeArray;
+import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.events.ContentSizeChangeEvent;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.views.scroll.OnScrollDispatchHelper;
+import com.facebook.react.views.scroll.ScrollEvent;
+import com.facebook.react.views.scroll.ScrollEventType;
+import com.reactnativecommunity.webview.events.TopMessageEvent;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+// TODO: change this comment
+/**
+ * Subclass of {@link WebView} that implements {@link LifecycleEventListener} interface in order
+ * to call {@link WebView#destroy} on activity destroy event and also to clear the client
+ */
+class RNCWebView extends FrameLayout implements LifecycleEventListener {
+  protected static final String JAVASCRIPT_INTERFACE = "ReactNativeWebView";
+
+  protected @Nullable
+  String injectedJS;
+  protected @Nullable
+  String injectedJSBeforeContentLoaded;
+
+  /**
+   * android.webkit.WebChromeClient fundamentally does not support JS injection into frames other
+   * than the main frame, so these two properties are mostly here just for parity with iOS & macOS.
+   */
+  protected boolean injectedJavaScriptForMainFrameOnly = true;
+  protected boolean injectedJavaScriptBeforeContentLoadedForMainFrameOnly = true;
+
+  protected boolean messagingEnabled = false;
+  protected @Nullable
+  String messagingModuleName;
+  protected @Nullable
+  RNCWebViewManager.RNCWebViewClient mRNCWebViewClient;
+  protected @Nullable
+  CatalystInstance mCatalystInstance;
+  protected boolean sendContentSizeChangeEvents = false;
+  private OnScrollDispatchHelper mOnScrollDispatchHelper;
+  protected boolean hasScrollEvent = false;
+  protected boolean nestedScrollEnabled = false;
+  protected ProgressChangedFilter progressChangedFilter;
+  WebView webView;
+
+  /**
+   * WebView must be created with an context of the current activity
+   * <p>
+   * Activity Context is required for creation of dialogs internally by WebView
+   * Reactive Native needed for access to ReactNative internal system functionality
+   */
+  public RNCWebView(ThemedReactContext reactContext) {
+    super(reactContext);
+    this.webView = new WebView(reactContext);
+    webView.setLayoutParams(new ViewGroup.LayoutParams(
+      ViewGroup.LayoutParams.MATCH_PARENT,
+      ViewGroup.LayoutParams.MATCH_PARENT));
+    addView(this.webView);
+    this.createCatalystInstance();
+    progressChangedFilter = new ProgressChangedFilter();
+  }
+
+  public WebView getWebView() {
+    return this.webView;
+  }
+
+  public WebSettings getSettings() {
+    return this.webView.getSettings();
+  }
+
+  public void setIgnoreErrFailedForThisURL(String url) {
+    mRNCWebViewClient.setIgnoreErrFailedForThisURL(url);
+  }
+
+  public void setBasicAuthCredential(BasicAuthCredential credential) {
+    mRNCWebViewClient.setBasicAuthCredential(credential);
+  }
+
+  public void setSendContentSizeChangeEvents(boolean sendContentSizeChangeEvents) {
+    this.sendContentSizeChangeEvents = sendContentSizeChangeEvents;
+  }
+
+  public void setHasScrollEvent(boolean hasScrollEvent) {
+    this.hasScrollEvent = hasScrollEvent;
+  }
+
+  public void setNestedScrollEnabled(boolean nestedScrollEnabled) {
+    this.nestedScrollEnabled = nestedScrollEnabled;
+  }
+
+  @Override
+  public void onHostResume() {
+    // do nothing
+  }
+
+  @Override
+  public void onHostPause() {
+    // do nothing
+  }
+
+  @Override
+  public void onHostDestroy() {
+    cleanupCallbacksAndDestroy();
+  }
+
+  @Override
+  public boolean onTouchEvent(MotionEvent event) {
+    if (this.nestedScrollEnabled) {
+      requestDisallowInterceptTouchEvent(true);
+    }
+    return super.onTouchEvent(event);
+  }
+
+  @Override
+  protected void onSizeChanged(int w, int h, int ow, int oh) {
+    super.onSizeChanged(w, h, ow, oh);
+
+    if (sendContentSizeChangeEvents) {
+      dispatchEvent(
+        this.webView,
+        new ContentSizeChangeEvent(
+          this.getId(),
+          w,
+          h
+        )
+      );
+    }
+  }
+
+  public void setWebViewClient(WebViewClient client) {
+    this.webView.setWebViewClient(client);
+    if (client instanceof RNCWebViewManager.RNCWebViewClient) {
+      mRNCWebViewClient = (RNCWebViewManager.RNCWebViewClient) client;
+      mRNCWebViewClient.setProgressChangedFilter(progressChangedFilter);
+    }
+  }
+
+  WebChromeClient mWebChromeClient;
+  public void setWebChromeClient(WebChromeClient client) {
+    this.mWebChromeClient = client;
+    this.webView.setWebChromeClient(client);
+    if (client instanceof RNCWebViewManager.RNCWebChromeClient) {
+      ((RNCWebViewManager.RNCWebChromeClient) client).setProgressChangedFilter(progressChangedFilter);
+    }
+  }
+
+  public @Nullable
+  RNCWebViewManager.RNCWebViewClient getRNCWebViewClient() {
+    return mRNCWebViewClient;
+  }
+
+  public void setInjectedJavaScript(@Nullable String js) {
+    injectedJS = js;
+  }
+
+  public void setInjectedJavaScriptBeforeContentLoaded(@Nullable String js) {
+    injectedJSBeforeContentLoaded = js;
+  }
+
+  public void setInjectedJavaScriptForMainFrameOnly(boolean enabled) {
+    injectedJavaScriptForMainFrameOnly = enabled;
+  }
+
+  public void setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(boolean enabled) {
+    injectedJavaScriptBeforeContentLoadedForMainFrameOnly = enabled;
+  }
+
+  protected RNCWebViewBridge createRNCWebViewBridge(RNCWebView webView) {
+    return new RNCWebViewBridge(webView);
+  }
+
+  protected void createCatalystInstance() {
+    ReactContext reactContext = (ReactContext) this.getContext();
+
+    if (reactContext != null) {
+      mCatalystInstance = reactContext.getCatalystInstance();
+    }
+  }
+
+  @SuppressLint("AddJavascriptInterface")
+  public void setMessagingEnabled(boolean enabled) {
+    if (messagingEnabled == enabled) {
+      return;
+    }
+
+    messagingEnabled = enabled;
+
+    if (enabled) {
+      this.webView.addJavascriptInterface(createRNCWebViewBridge(this), JAVASCRIPT_INTERFACE);
+    } else {
+      this.webView.removeJavascriptInterface(JAVASCRIPT_INTERFACE);
+    }
+  }
+
+  public void setMessagingModuleName(String moduleName) {
+    messagingModuleName = moduleName;
+  }
+
+  protected void evaluateJavascriptWithFallback(String script) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+      this.webView.evaluateJavascript(script, null);
+      return;
+    }
+
+    try {
+      this.webView.loadUrl("javascript:" + URLEncoder.encode(script, "UTF-8"));
+    } catch (UnsupportedEncodingException e) {
+      // UTF-8 should always be supported
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void callInjectedJavaScript() {
+    if (this.webView.getSettings().getJavaScriptEnabled() &&
+      injectedJS != null &&
+      !TextUtils.isEmpty(injectedJS)) {
+      evaluateJavascriptWithFallback("(function() {\n" + injectedJS + ";\n})();");
+    }
+  }
+
+  public void callInjectedJavaScriptBeforeContentLoaded() {
+    if (this.webView.getSettings().getJavaScriptEnabled() &&
+      injectedJSBeforeContentLoaded != null &&
+      !TextUtils.isEmpty(injectedJSBeforeContentLoaded)) {
+      evaluateJavascriptWithFallback("(function() {\n" + injectedJSBeforeContentLoaded + ";\n})();");
+    }
+  }
+
+  public void onMessage(String message) {
+    ReactContext reactContext = (ReactContext) this.getContext();
+    RNCWebView mContext = this;
+
+    if (mRNCWebViewClient != null) {
+      WebView webView = this.webView;
+      webView.post(new Runnable() {
+        @Override
+        public void run() {
+          if (mRNCWebViewClient == null) {
+            return;
+          }
+          WritableMap data = mRNCWebViewClient.createWebViewEvent(webView, webView.getUrl());
+          data.putString("data", message);
+
+          if (mCatalystInstance != null) {
+            mContext.sendDirectMessage("onMessage", data);
+          } else {
+            dispatchEvent(webView, new TopMessageEvent(webView.getId(), data));
+          }
+        }
+      });
+    } else {
+      WritableMap eventData = Arguments.createMap();
+      eventData.putString("data", message);
+
+      if (mCatalystInstance != null) {
+        this.sendDirectMessage("onMessage", eventData);
+      } else {
+        dispatchEvent(this.webView, new TopMessageEvent(this.getId(), eventData));
+      }
+    }
+  }
+
+  protected void sendDirectMessage(final String method, WritableMap data) {
+    WritableNativeMap event = new WritableNativeMap();
+    event.putMap("nativeEvent", data);
+
+    WritableNativeArray params = new WritableNativeArray();
+    params.pushMap(event);
+
+    mCatalystInstance.callFunction(messagingModuleName, method, params);
+  }
+
+  protected void onScrollChanged(int x, int y, int oldX, int oldY) {
+    super.onScrollChanged(x, y, oldX, oldY);
+
+    if (!hasScrollEvent) {
+      return;
+    }
+
+    if (mOnScrollDispatchHelper == null) {
+      mOnScrollDispatchHelper = new OnScrollDispatchHelper();
+    }
+
+    if (mOnScrollDispatchHelper.onScrollChanged(x, y)) {
+      ScrollEvent event = ScrollEvent.obtain(
+        this.getId(),
+        ScrollEventType.SCROLL,
+        x,
+        y,
+        mOnScrollDispatchHelper.getXFlingVelocity(),
+        mOnScrollDispatchHelper.getYFlingVelocity(),
+        this.computeHorizontalScrollRange(),
+        this.computeVerticalScrollRange(),
+        this.getWidth(),
+        this.getHeight());
+
+      dispatchEvent(this.webView, event);
+    }
+  }
+
+  protected void dispatchEvent(WebView webView, Event event) {
+    ReactContext reactContext = (ReactContext) webView.getContext();
+    EventDispatcher eventDispatcher =
+      reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+    eventDispatcher.dispatchEvent(event);
+  }
+
+  protected void cleanupCallbacksAndDestroy() {
+    setWebViewClient(null);
+    destroy();
+  }
+
+  public void destroy() {
+    if (mWebChromeClient != null) {
+      mWebChromeClient.onHideCustomView();
+    }
+    this.webView.destroy();
+  }
+
+  protected class RNCWebViewBridge {
+    RNCWebView mContext;
+
+    RNCWebViewBridge(RNCWebView c) {
+      mContext = c;
+    }
+
+    /**
+     * This method is called whenever JavaScript running within the web view calls:
+     * - window[JAVASCRIPT_INTERFACE].postMessage
+     */
+    @JavascriptInterface
+    public void postMessage(String message) {
+      mContext.onMessage(message);
+    }
+  }
+
+  protected static class ProgressChangedFilter {
+    private boolean waitingForCommandLoadUrl = false;
+
+    public void setWaitingForCommandLoadUrl(boolean isWaiting) {
+      waitingForCommandLoadUrl = isWaiting;
+    }
+
+    public boolean isWaitingForCommandLoadUrl() {
+      return waitingForCommandLoadUrl;
+    }
+  }
+}

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -66,6 +66,9 @@ class RNCWebView extends FrameLayout implements LifecycleEventListener {
   protected boolean hasScrollEvent = false;
   protected boolean nestedScrollEnabled = false;
   protected ProgressChangedFilter progressChangedFilter;
+  protected boolean keepWebViewInstanceAfterUnmount = false;
+  protected @Nullable String webViewKey = null;
+  protected boolean sourceInitialized = false;
   WebView webView;
 
   /**
@@ -87,6 +90,14 @@ class RNCWebView extends FrameLayout implements LifecycleEventListener {
 
   public WebView getWebView() {
     return this.webView;
+  }
+
+  public void setWebView(WebView webView) {
+    this.webView = webView;
+    webView.setLayoutParams(new ViewGroup.LayoutParams(
+      ViewGroup.LayoutParams.MATCH_PARENT,
+      ViewGroup.LayoutParams.MATCH_PARENT));
+    addView(this.webView);
   }
 
   public WebSettings getSettings() {
@@ -111,6 +122,14 @@ class RNCWebView extends FrameLayout implements LifecycleEventListener {
 
   public void setNestedScrollEnabled(boolean nestedScrollEnabled) {
     this.nestedScrollEnabled = nestedScrollEnabled;
+  }
+
+  public void markSourceInitialized() {
+    this.sourceInitialized = true;
+  }
+
+  public boolean isSourceInitialized() {
+    return this.sourceInitialized;
   }
 
   @Override
@@ -188,6 +207,22 @@ class RNCWebView extends FrameLayout implements LifecycleEventListener {
 
   public void setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(boolean enabled) {
     injectedJavaScriptBeforeContentLoadedForMainFrameOnly = enabled;
+  }
+
+  public void setKeepWebViewInstanceAfterUnmount(boolean keep) {
+    keepWebViewInstanceAfterUnmount = keep;
+  }
+
+  public void setWebViewKey(String key) {
+    webViewKey = key;
+  }
+
+  public String getWebViewKey() {
+    return webViewKey;
+  }
+
+  public boolean configuredToKeepWebViewInstance() {
+    return this.keepWebViewInstanceAfterUnmount && this.webViewKey != null;
   }
 
   protected RNCWebViewBridge createRNCWebViewBridge(RNCWebView webView) {

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -29,7 +29,6 @@ import android.webkit.CookieManager;
 import android.webkit.DownloadListener;
 import android.webkit.GeolocationPermissions;
 import android.webkit.HttpAuthHandler;
-import android.webkit.JavascriptInterface;
 import android.webkit.RenderProcessGoneDetail;
 import android.webkit.SslErrorHandler;
 import android.webkit.PermissionRequest;
@@ -128,7 +127,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * - canGoForward - boolean, whether it is possible to request GO_FORWARD command
  */
 @ReactModule(name = RNCWebViewManager.REACT_CLASS)
-public class RNCWebViewManager extends SimpleViewManager<WebView> {
+public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
   private static final String TAG = "RNCWebViewManager";
 
   public static final int COMMAND_GO_BACK = 1;
@@ -140,6 +139,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   public static final int COMMAND_LOAD_URL = 7;
   public static final int COMMAND_FOCUS = 8;
 
+  // commands added by Discord
+  public static final int COMMAND_RELEASE = 4001;
+
   // android commands
   public static final int COMMAND_CLEAR_FORM_DATA = 1000;
   public static final int COMMAND_CLEAR_CACHE = 1001;
@@ -148,7 +150,6 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   protected static final String REACT_CLASS = "RNCWebView";
   protected static final String HTML_ENCODING = "UTF-8";
   protected static final String HTML_MIME_TYPE = "text/html";
-  protected static final String JAVASCRIPT_INTERFACE = "ReactNativeWebView";
   protected static final String HTTP_METHOD_POST = "POST";
   // Use `webView.loadUrl("about:blank")` to reliably reset the view
   // state and release page resources (including any running JavaScript).
@@ -188,12 +189,14 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   @Override
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-  protected WebView createViewInstance(ThemedReactContext reactContext) {
-    RNCWebView webView = createRNCWebViewInstance(reactContext);
-    setupWebChromeClient(reactContext, webView);
-    reactContext.addLifecycleEventListener(webView);
-    mWebViewConfig.configWebView(webView);
-    WebSettings settings = webView.getSettings();
+  protected RNCWebView createViewInstance(ThemedReactContext reactContext) {
+    RNCWebView rncWebView = createRNCWebViewInstance(reactContext);
+
+    // TODO: move setupWebChromeClient, configWebView, and WebSettings into RNCWebView.java
+    setupWebChromeClient(reactContext, rncWebView);
+    reactContext.addLifecycleEventListener(rncWebView);
+    mWebViewConfig.configWebView(rncWebView.webView);
+    WebSettings settings = rncWebView.webView.getSettings();
     settings.setBuiltInZoomControls(true);
     settings.setDisplayZoomControls(false);
     settings.setDomStorageEnabled(true);
@@ -203,12 +206,12 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     settings.setAllowContentAccess(false);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
       settings.setAllowFileAccessFromFileURLs(false);
-      setAllowUniversalAccessFromFileURLs(webView, false);
+      setAllowUniversalAccessFromFileURLs(rncWebView, false);
     }
-    setMixedContentMode(webView, "never");
+    setMixedContentMode(rncWebView, "never");
 
     // Fixes broken full-screen modals/galleries due to body height being 0.
-    webView.setLayoutParams(
+    rncWebView.setLayoutParams(
       new LayoutParams(LayoutParams.MATCH_PARENT,
         LayoutParams.MATCH_PARENT));
 
@@ -216,9 +219,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       WebView.setWebContentsDebuggingEnabled(true);
     }
 
-    webView.setDownloadListener(new DownloadListener() {
+    rncWebView.webView.setDownloadListener(new DownloadListener() {
       public void onDownloadStart(String url, String userAgent, String contentDisposition, String mimetype, long contentLength) {
-        webView.setIgnoreErrFailedForThisURL(url);
+        rncWebView.setIgnoreErrFailedForThisURL(url);
 
         RNCWebViewModule module = getModule(reactContext);
 
@@ -260,7 +263,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       }
     });
 
-    return webView;
+    return rncWebView;
   }
 
   private String getDownloadingMessage() {
@@ -272,47 +275,47 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   }
 
   @ReactProp(name = "javaScriptEnabled")
-  public void setJavaScriptEnabled(WebView view, boolean enabled) {
+  public void setJavaScriptEnabled(RNCWebView view, boolean enabled) {
     view.getSettings().setJavaScriptEnabled(enabled);
   }
 
   @ReactProp(name = "setBuiltInZoomControls")
-  public void setBuiltInZoomControls(WebView view, boolean enabled) {
+  public void setBuiltInZoomControls(RNCWebView view, boolean enabled) {
     view.getSettings().setBuiltInZoomControls(enabled);
   }
 
   @ReactProp(name = "setDisplayZoomControls")
-  public void setDisplayZoomControls(WebView view, boolean enabled) {
+  public void setDisplayZoomControls(RNCWebView view, boolean enabled) {
     view.getSettings().setDisplayZoomControls(enabled);
   }
 
   @ReactProp(name = "setSupportMultipleWindows")
-  public void setSupportMultipleWindows(WebView view, boolean enabled){
+  public void setSupportMultipleWindows(RNCWebView view, boolean enabled){
     view.getSettings().setSupportMultipleWindows(enabled);
   }
 
   @ReactProp(name = "showsHorizontalScrollIndicator")
-  public void setShowsHorizontalScrollIndicator(WebView view, boolean enabled) {
+  public void setShowsHorizontalScrollIndicator(RNCWebView view, boolean enabled) {
     view.setHorizontalScrollBarEnabled(enabled);
   }
 
   @ReactProp(name = "showsVerticalScrollIndicator")
-  public void setShowsVerticalScrollIndicator(WebView view, boolean enabled) {
+  public void setShowsVerticalScrollIndicator(RNCWebView view, boolean enabled) {
     view.setVerticalScrollBarEnabled(enabled);
   }
 
   @ReactProp(name = "downloadingMessage")
-  public void setDownloadingMessage(WebView view, String message) {
+  public void setDownloadingMessage(RNCWebView view, String message) {
     mDownloadingMessage = message;
   }
 
   @ReactProp(name = "lackPermissionToDownloadMessage")
-  public void setLackPermissionToDownlaodMessage(WebView view, String message) {
+  public void setLackPermissionToDownlaodMessage(RNCWebView view, String message) {
     mLackPermissionToDownloadMessage = message;
   }
 
   @ReactProp(name = "cacheEnabled")
-  public void setCacheEnabled(WebView view, boolean enabled) {
+  public void setCacheEnabled(RNCWebView view, boolean enabled) {
     if (enabled) {
       Context ctx = view.getContext();
       if (ctx != null) {
@@ -324,7 +327,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   }
 
   @ReactProp(name = "cacheMode")
-  public void setCacheMode(WebView view, String cacheModeString) {
+  public void setCacheMode(RNCWebView view, String cacheModeString) {
     Integer cacheMode;
     switch (cacheModeString) {
       case "LOAD_CACHE_ONLY":
@@ -345,14 +348,14 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   }
 
   @ReactProp(name = "androidHardwareAccelerationDisabled")
-  public void setHardwareAccelerationDisabled(WebView view, boolean disabled) {
+  public void setHardwareAccelerationDisabled(RNCWebView view, boolean disabled) {
     if (disabled) {
       view.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
     }
   }
 
   @ReactProp(name = "androidLayerType")
-  public void setLayerType(WebView view, String layerTypeString) {
+  public void setLayerType(RNCWebView view, String layerTypeString) {
     int layerType = View.LAYER_TYPE_NONE;
     switch (layerTypeString) {
         case "hardware":
@@ -367,7 +370,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
 
   @ReactProp(name = "overScrollMode")
-  public void setOverScrollMode(WebView view, String overScrollModeString) {
+  public void setOverScrollMode(RNCWebView view, String overScrollModeString) {
     Integer overScrollMode;
     switch (overScrollModeString) {
       case "never":
@@ -385,35 +388,35 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   }
 
   @ReactProp(name = "nestedScrollEnabled")
-  public void setNestedScrollEnabled(WebView view, boolean enabled) {
-    ((RNCWebView) view).setNestedScrollEnabled(enabled);
+  public void setNestedScrollEnabled(RNCWebView view, boolean enabled) {
+    view.setNestedScrollEnabled(enabled);
   }
 
   @ReactProp(name = "thirdPartyCookiesEnabled")
-  public void setThirdPartyCookiesEnabled(WebView view, boolean enabled) {
+  public void setThirdPartyCookiesEnabled(RNCWebView view, boolean enabled) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      CookieManager.getInstance().setAcceptThirdPartyCookies(view, enabled);
+      CookieManager.getInstance().setAcceptThirdPartyCookies(view.getWebView(), enabled);
     }
   }
 
   @ReactProp(name = "textZoom")
-  public void setTextZoom(WebView view, int value) {
+  public void setTextZoom(RNCWebView view, int value) {
     view.getSettings().setTextZoom(value);
   }
 
   @ReactProp(name = "scalesPageToFit")
-  public void setScalesPageToFit(WebView view, boolean enabled) {
+  public void setScalesPageToFit(RNCWebView view, boolean enabled) {
     view.getSettings().setLoadWithOverviewMode(enabled);
     view.getSettings().setUseWideViewPort(enabled);
   }
 
   @ReactProp(name = "domStorageEnabled")
-  public void setDomStorageEnabled(WebView view, boolean enabled) {
+  public void setDomStorageEnabled(RNCWebView view, boolean enabled) {
     view.getSettings().setDomStorageEnabled(enabled);
   }
 
   @ReactProp(name = "userAgent")
-  public void setUserAgent(WebView view, @Nullable String userAgent) {
+  public void setUserAgent(RNCWebView view, @Nullable String userAgent) {
     if (userAgent != null) {
       mUserAgent = userAgent;
     } else {
@@ -423,7 +426,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   }
 
   @ReactProp(name = "applicationNameForUserAgent")
-  public void setApplicationNameForUserAgent(WebView view, @Nullable String applicationName) {
+  public void setApplicationNameForUserAgent(RNCWebView view, @Nullable String applicationName) {
     if(applicationName != null) {
       if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
         String defaultUserAgent = WebSettings.getDefaultUserAgent(view.getContext());
@@ -435,7 +438,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     this.setUserAgentString(view);
   }
 
-  protected void setUserAgentString(WebView view) {
+  protected void setUserAgentString(RNCWebView view) {
     if(mUserAgent != null) {
       view.getSettings().setUserAgentString(mUserAgent);
     } else if(mUserAgentWithApplicationName != null) {
@@ -448,62 +451,62 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
   @ReactProp(name = "mediaPlaybackRequiresUserAction")
-  public void setMediaPlaybackRequiresUserAction(WebView view, boolean requires) {
+  public void setMediaPlaybackRequiresUserAction(RNCWebView view, boolean requires) {
     view.getSettings().setMediaPlaybackRequiresUserGesture(requires);
   }
 
   @ReactProp(name = "javaScriptCanOpenWindowsAutomatically")
-  public void setJavaScriptCanOpenWindowsAutomatically(WebView view, boolean enabled) {
+  public void setJavaScriptCanOpenWindowsAutomatically(RNCWebView view, boolean enabled) {
     view.getSettings().setJavaScriptCanOpenWindowsAutomatically(enabled);
   }
 
   @ReactProp(name = "allowFileAccessFromFileURLs")
-  public void setAllowFileAccessFromFileURLs(WebView view, boolean allow) {
+  public void setAllowFileAccessFromFileURLs(RNCWebView view, boolean allow) {
     view.getSettings().setAllowFileAccessFromFileURLs(allow);
   }
 
   @ReactProp(name = "allowUniversalAccessFromFileURLs")
-  public void setAllowUniversalAccessFromFileURLs(WebView view, boolean allow) {
+  public void setAllowUniversalAccessFromFileURLs(RNCWebView view, boolean allow) {
     view.getSettings().setAllowUniversalAccessFromFileURLs(allow);
   }
 
   @ReactProp(name = "saveFormDataDisabled")
-  public void setSaveFormDataDisabled(WebView view, boolean disable) {
+  public void setSaveFormDataDisabled(RNCWebView view, boolean disable) {
     view.getSettings().setSaveFormData(!disable);
   }
 
   @ReactProp(name = "injectedJavaScript")
-  public void setInjectedJavaScript(WebView view, @Nullable String injectedJavaScript) {
-    ((RNCWebView) view).setInjectedJavaScript(injectedJavaScript);
+  public void setInjectedJavaScript(RNCWebView view, @Nullable String injectedJavaScript) {
+    view.setInjectedJavaScript(injectedJavaScript);
   }
 
   @ReactProp(name = "injectedJavaScriptBeforeContentLoaded")
-  public void setInjectedJavaScriptBeforeContentLoaded(WebView view, @Nullable String injectedJavaScriptBeforeContentLoaded) {
-    ((RNCWebView) view).setInjectedJavaScriptBeforeContentLoaded(injectedJavaScriptBeforeContentLoaded);
+  public void setInjectedJavaScriptBeforeContentLoaded(RNCWebView view, @Nullable String injectedJavaScriptBeforeContentLoaded) {
+    view.setInjectedJavaScriptBeforeContentLoaded(injectedJavaScriptBeforeContentLoaded);
   }
 
   @ReactProp(name = "injectedJavaScriptForMainFrameOnly")
-  public void setInjectedJavaScriptForMainFrameOnly(WebView view, boolean enabled) {
-    ((RNCWebView) view).setInjectedJavaScriptForMainFrameOnly(enabled);
+  public void setInjectedJavaScriptForMainFrameOnly(RNCWebView view, boolean enabled) {
+    view.setInjectedJavaScriptForMainFrameOnly(enabled);
   }
 
   @ReactProp(name = "injectedJavaScriptBeforeContentLoadedForMainFrameOnly")
-  public void setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(WebView view, boolean enabled) {
-    ((RNCWebView) view).setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(enabled);
+  public void setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(RNCWebView view, boolean enabled) {
+    view.setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(enabled);
   }
 
   @ReactProp(name = "messagingEnabled")
-  public void setMessagingEnabled(WebView view, boolean enabled) {
-    ((RNCWebView) view).setMessagingEnabled(enabled);
+  public void setMessagingEnabled(RNCWebView view, boolean enabled) {
+    view.setMessagingEnabled(enabled);
   }
 
   @ReactProp(name = "messagingModuleName")
-  public void setMessagingModuleName(WebView view, String moduleName) {
-    ((RNCWebView) view).setMessagingModuleName(moduleName);
+  public void setMessagingModuleName(RNCWebView view, String moduleName) {
+    view.setMessagingModuleName(moduleName);
   }
 
   @ReactProp(name = "incognito")
-  public void setIncognito(WebView view, boolean enabled) {
+  public void setIncognito(RNCWebView view, boolean enabled) {
     // Don't do anything when incognito is disabled
     if (!enabled) {
       return;
@@ -518,27 +521,27 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     // Disable caching
     view.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
-    view.clearHistory();
-    view.clearCache(true);
+    view.getWebView().clearHistory();
+    view.getWebView().clearCache(true);
 
     // No form data or autofill enabled
-    view.clearFormData();
+    view.getWebView().clearFormData();
     view.getSettings().setSavePassword(false);
     view.getSettings().setSaveFormData(false);
   }
 
   @ReactProp(name = "source")
-  public void setSource(WebView view, @Nullable ReadableMap source) {
+  public void setSource(RNCWebView view, @Nullable ReadableMap source) {
     if (source != null) {
       if (source.hasKey("html")) {
         String html = source.getString("html");
         String baseUrl = source.hasKey("baseUrl") ? source.getString("baseUrl") : "";
-        view.loadDataWithBaseURL(baseUrl, html, HTML_MIME_TYPE, HTML_ENCODING, null);
+        view.getWebView().loadDataWithBaseURL(baseUrl, html, HTML_MIME_TYPE, HTML_ENCODING, null);
         return;
       }
       if (source.hasKey("uri")) {
         String url = source.getString("uri");
-        String previousUrl = view.getUrl();
+        String previousUrl = view.getWebView().getUrl();
         if (previousUrl != null && previousUrl.equals(url)) {
           return;
         }
@@ -557,7 +560,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
             if (postData == null) {
               postData = new byte[0];
             }
-            view.postUrl(url, postData);
+            view.getWebView().postUrl(url, postData);
             return;
           }
         }
@@ -576,15 +579,15 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
             }
           }
         }
-        view.loadUrl(url, headerMap);
+        view.getWebView().loadUrl(url, headerMap);
         return;
       }
     }
-    view.loadUrl(BLANK_URL);
+    view.getWebView().loadUrl(BLANK_URL);
   }
 
   @ReactProp(name = "basicAuthCredential")
-  public void setBasicAuthCredential(WebView view, @Nullable ReadableMap credential) {
+  public void setBasicAuthCredential(RNCWebView view, @Nullable ReadableMap credential) {
     @Nullable BasicAuthCredential basicAuthCredential = null;
     if (credential != null) {
       if (credential.hasKey("username") && credential.hasKey("password")) {
@@ -593,16 +596,16 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         basicAuthCredential = new BasicAuthCredential(username, password);
       }
     }
-    ((RNCWebView) view).setBasicAuthCredential(basicAuthCredential);
+    view.setBasicAuthCredential(basicAuthCredential);
   }
 
   @ReactProp(name = "onContentSizeChange")
-  public void setOnContentSizeChange(WebView view, boolean sendContentSizeChangeEvents) {
-    ((RNCWebView) view).setSendContentSizeChangeEvents(sendContentSizeChangeEvents);
+  public void setOnContentSizeChange(RNCWebView view, boolean sendContentSizeChangeEvents) {
+    view.setSendContentSizeChangeEvents(sendContentSizeChangeEvents);
   }
 
   @ReactProp(name = "mixedContentMode")
-  public void setMixedContentMode(WebView view, @Nullable String mixedContentMode) {
+  public void setMixedContentMode(RNCWebView view, @Nullable String mixedContentMode) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       if (mixedContentMode == null || "never".equals(mixedContentMode)) {
         view.getSettings().setMixedContentMode(WebSettings.MIXED_CONTENT_NEVER_ALLOW);
@@ -616,9 +619,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   @ReactProp(name = "urlPrefixesForDefaultIntent")
   public void setUrlPrefixesForDefaultIntent(
-    WebView view,
+    RNCWebView view,
     @Nullable ReadableArray urlPrefixesForDefaultIntent) {
-    RNCWebViewClient client = ((RNCWebView) view).getRNCWebViewClient();
+    RNCWebViewClient client = view.getRNCWebViewClient();
     if (client != null && urlPrefixesForDefaultIntent != null) {
       client.setUrlPrefixesForDefaultIntent(urlPrefixesForDefaultIntent);
     }
@@ -626,7 +629,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   @ReactProp(name = "allowsFullscreenVideo")
   public void setAllowsFullscreenVideo(
-    WebView view,
+    RNCWebView view,
     @Nullable Boolean allowsFullscreenVideo) {
     mAllowsFullscreenVideo = allowsFullscreenVideo != null && allowsFullscreenVideo;
     setupWebChromeClient((ReactContext)view.getContext(), view);
@@ -634,25 +637,25 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   @ReactProp(name = "allowFileAccess")
   public void setAllowFileAccess(
-    WebView view,
+    RNCWebView view,
     @Nullable Boolean allowFileAccess) {
     view.getSettings().setAllowFileAccess(allowFileAccess != null && allowFileAccess);
   }
 
   @ReactProp(name = "geolocationEnabled")
   public void setGeolocationEnabled(
-    WebView view,
+    RNCWebView view,
     @Nullable Boolean isGeolocationEnabled) {
     view.getSettings().setGeolocationEnabled(isGeolocationEnabled != null && isGeolocationEnabled);
   }
 
   @ReactProp(name = "onScroll")
-  public void setOnScroll(WebView view, boolean hasScrollEvent) {
-    ((RNCWebView) view).setHasScrollEvent(hasScrollEvent);
+  public void setOnScroll(RNCWebView view, boolean hasScrollEvent) {
+    view.setHasScrollEvent(hasScrollEvent);
   }
 
   @ReactProp(name = "forceDarkOn")
-  public void setForceDarkOn(WebView view, boolean enabled) {
+  public void setForceDarkOn(RNCWebView view, boolean enabled) {
     // Only Android 10+ support dark mode
     if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
       // Switch WebView dark mode
@@ -673,14 +676,14 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   }
 
   @ReactProp(name = "minimumFontSize")
-  public void setMinimumFontSize(WebView view, int fontSize) {
+  public void setMinimumFontSize(RNCWebView view, int fontSize) {
     view.getSettings().setMinimumFontSize(fontSize);
   }
 
   @Override
-  protected void addEventEmitters(ThemedReactContext reactContext, WebView view) {
+  protected void addEventEmitters(ThemedReactContext reactContext, RNCWebView view) {
     // Do not register default touch emitter and let WebView implementation handle touches
-    view.setWebViewClient(new RNCWebViewClient());
+    view.setWebViewClient(new RNCWebViewClient(view));
   }
 
   @Override
@@ -719,27 +722,28 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       .put("clearFormData", COMMAND_CLEAR_FORM_DATA)
       .put("clearCache", COMMAND_CLEAR_CACHE)
       .put("clearHistory", COMMAND_CLEAR_HISTORY)
+      .put("release", COMMAND_RELEASE)
       .build();
   }
 
   @Override
-  public void receiveCommand(@NonNull WebView root, String commandId, @Nullable ReadableArray args) {
+  public void receiveCommand(@NonNull RNCWebView root, String commandId, @Nullable ReadableArray args) {
     switch (commandId) {
       case "goBack":
-        root.goBack();
+        root.getWebView().goBack();
         break;
       case "goForward":
-        root.goForward();
+        root.getWebView().goForward();
         break;
       case "reload":
-        root.reload();
+        root.getWebView().reload();
         break;
       case "stopLoading":
-        root.stopLoading();
+        root.getWebView().stopLoading();
         break;
       case "postMessage":
         try {
-          RNCWebView reactWebView = (RNCWebView) root;
+          RNCWebView reactWebView = root;
           JSONObject eventInitDict = new JSONObject();
           eventInitDict.put("data", args.getString(0));
           reactWebView.evaluateJavascriptWithFallback("(function () {" +
@@ -758,38 +762,41 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         }
         break;
       case "injectJavaScript":
-        RNCWebView reactWebView = (RNCWebView) root;
+        RNCWebView reactWebView = root;
         reactWebView.evaluateJavascriptWithFallback(args.getString(0));
         break;
       case "loadUrl":
         if (args == null) {
           throw new RuntimeException("Arguments for loading an url are null!");
         }
-        ((RNCWebView) root).progressChangedFilter.setWaitingForCommandLoadUrl(false);
-        root.loadUrl(args.getString(0));
+        root.progressChangedFilter.setWaitingForCommandLoadUrl(false);
+        root.getWebView().loadUrl(args.getString(0));
         break;
       case "requestFocus":
-        root.requestFocus();
+        root.getWebView().requestFocus();
         break;
       case "clearFormData":
-        root.clearFormData();
+        root.getWebView().clearFormData();
         break;
       case "clearCache":
         boolean includeDiskFiles = args != null && args.getBoolean(0);
-        root.clearCache(includeDiskFiles);
+        root.getWebView().clearCache(includeDiskFiles);
         break;
       case "clearHistory":
-        root.clearHistory();
+        root.getWebView().clearHistory();
+        break;
+      case "release":
+        // no-op for now
         break;
     }
     super.receiveCommand(root, commandId, args);
   }
 
   @Override
-  public void onDropViewInstance(WebView webView) {
-    super.onDropViewInstance(webView);
-    ((ThemedReactContext) webView.getContext()).removeLifecycleEventListener((RNCWebView) webView);
-    ((RNCWebView) webView).cleanupCallbacksAndDestroy();
+  public void onDropViewInstance(RNCWebView rncWebView) {
+    super.onDropViewInstance(rncWebView);
+    ((ThemedReactContext) rncWebView.getContext()).removeLifecycleEventListener(rncWebView);
+    rncWebView.cleanupCallbacksAndDestroy();
     mWebChromeClient = null;
   }
 
@@ -797,13 +804,13 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     return reactContext.getNativeModule(RNCWebViewModule.class);
   }
 
-  protected void setupWebChromeClient(ReactContext reactContext, WebView webView) {
+  protected void setupWebChromeClient(ReactContext reactContext, RNCWebView rncWebView) {
     Activity activity = reactContext.getCurrentActivity();
 
     if (mAllowsFullscreenVideo && activity != null) {
       int initialRequestedOrientation = activity.getRequestedOrientation();
 
-      mWebChromeClient = new RNCWebChromeClient(reactContext, webView) {
+      mWebChromeClient = new RNCWebChromeClient(reactContext, rncWebView) {
         @Override
         public Bitmap getDefaultVideoPoster() {
           return Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888);
@@ -883,20 +890,20 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         }
       };
 
-      webView.setWebChromeClient(mWebChromeClient);
+      rncWebView.setWebChromeClient(mWebChromeClient);
     } else {
       if (mWebChromeClient != null) {
         mWebChromeClient.onHideCustomView();
       }
 
-      mWebChromeClient = new RNCWebChromeClient(reactContext, webView) {
+      mWebChromeClient = new RNCWebChromeClient(reactContext, rncWebView) {
         @Override
         public Bitmap getDefaultVideoPoster() {
           return Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888);
         }
       };
 
-      webView.setWebChromeClient(mWebChromeClient);
+      rncWebView.setWebChromeClient(mWebChromeClient);
     }
   }
 
@@ -908,6 +915,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     protected RNCWebView.ProgressChangedFilter progressChangedFilter = null;
     protected @Nullable String ignoreErrFailedForThisURL = null;
     protected @Nullable BasicAuthCredential basicAuthCredential = null;
+    protected RNCWebView rncWebView;
+
+    public RNCWebViewClient(RNCWebView rncWebView) {
+      this.rncWebView = rncWebView;
+    }
 
     public void setIgnoreErrFailedForThisURL(@Nullable String url) {
       ignoreErrFailedForThisURL = url;
@@ -922,9 +934,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       super.onPageFinished(webView, url);
 
       if (!mLastLoadFailed) {
-        RNCWebView reactWebView = (RNCWebView) webView;
-
-        reactWebView.callInjectedJavaScript();
+        this.rncWebView.callInjectedJavaScript();
 
         emitFinishEvent(webView, url);
       }
@@ -935,10 +945,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       super.onPageStarted(webView, url, favicon);
       mLastLoadFailed = false;
 
-      RNCWebView reactWebView = (RNCWebView) webView;
-      reactWebView.callInjectedJavaScriptBeforeContentLoaded();
+      this.rncWebView.callInjectedJavaScriptBeforeContentLoaded();
 
-      ((RNCWebView) webView).dispatchEvent(
+      this.rncWebView.dispatchEvent(
         webView,
         new TopLoadingStartEvent(
           webView.getId(),
@@ -947,7 +956,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
-      final RNCWebView rncWebView = (RNCWebView) view;
+      final RNCWebView rncWebView = this.rncWebView;
       final boolean isJsDebugging = ((ReactContext) view.getContext()).getJavaScriptContextHolder().get() == 0;
 
       if (!isJsDebugging && rncWebView.mCatalystInstance != null) {
@@ -985,7 +994,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       } else {
         FLog.w(TAG, "Couldn't use blocking synchronous call for onShouldStartLoadWithRequest due to debugging or missing Catalyst instance, falling back to old event-and-load.");
         progressChangedFilter.setWaitingForCommandLoadUrl(true);
-        ((RNCWebView) view).dispatchEvent(
+        this.rncWebView.dispatchEvent(
           view,
           new TopShouldStartLoadWithRequestEvent(
             view.getId(),
@@ -1101,7 +1110,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       eventData.putDouble("code", errorCode);
       eventData.putString("description", description);
 
-      ((RNCWebView) webView).dispatchEvent(
+      this.rncWebView.dispatchEvent(
         webView,
         new TopLoadingErrorEvent(webView.getId(), eventData));
     }
@@ -1119,7 +1128,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         eventData.putInt("statusCode", errorResponse.getStatusCode());
         eventData.putString("description", errorResponse.getReasonPhrase());
 
-        ((RNCWebView) webView).dispatchEvent(
+        this.rncWebView.dispatchEvent(
           webView,
           new TopHttpErrorEvent(webView.getId(), eventData));
       }
@@ -1151,7 +1160,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         WritableMap event = createWebViewEvent(webView, webView.getUrl());
         event.putBoolean("didCrash", detail.didCrash());
 
-      ((RNCWebView) webView).dispatchEvent(
+      this.rncWebView.dispatchEvent(
           webView,
           new TopRenderProcessGoneEvent(webView.getId(), event)
         );
@@ -1161,7 +1170,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     }
 
     protected void emitFinishEvent(WebView webView, String url) {
-      ((RNCWebView) webView).dispatchEvent(
+      this.rncWebView.dispatchEvent(
         webView,
         new TopLoadingFinishEvent(
           webView.getId(),
@@ -1210,6 +1219,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     protected View mVideoView;
     protected WebChromeClient.CustomViewCallback mCustomViewCallback;
+    protected RNCWebView mRncWebView;
 
     /*
      * - Permissions -
@@ -1234,9 +1244,10 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     protected RNCWebView.ProgressChangedFilter progressChangedFilter = null;
 
-    public RNCWebChromeClient(ReactContext reactContext, WebView webView) {
+    public RNCWebChromeClient(ReactContext reactContext, RNCWebView rncWebView) {
       this.mReactContext = reactContext;
-      this.mWebView = webView;
+      this.mRncWebView = rncWebView;
+      this.mWebView = rncWebView.getWebView();
     }
 
     @Override
@@ -1273,7 +1284,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       event.putBoolean("canGoBack", webView.canGoBack());
       event.putBoolean("canGoForward", webView.canGoForward());
       event.putDouble("progress", (float) newProgress / 100);
-      ((RNCWebView) webView).dispatchEvent(
+      this.mRncWebView.dispatchEvent(
         webView,
         new TopLoadingProgressEvent(
           webView.getId(),
@@ -1486,330 +1497,6 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     public void setProgressChangedFilter(RNCWebView.ProgressChangedFilter filter) {
       progressChangedFilter = filter;
-    }
-  }
-
-  /**
-   * Subclass of {@link WebView} that implements {@link LifecycleEventListener} interface in order
-   * to call {@link WebView#destroy} on activity destroy event and also to clear the client
-   */
-  protected static class RNCWebView extends WebView implements LifecycleEventListener {
-    protected @Nullable
-    String injectedJS;
-    protected @Nullable
-    String injectedJSBeforeContentLoaded;
-
-    /**
-     * android.webkit.WebChromeClient fundamentally does not support JS injection into frames other
-     * than the main frame, so these two properties are mostly here just for parity with iOS & macOS.
-     */
-    protected boolean injectedJavaScriptForMainFrameOnly = true;
-    protected boolean injectedJavaScriptBeforeContentLoadedForMainFrameOnly = true;
-
-    protected boolean messagingEnabled = false;
-    protected @Nullable
-    String messagingModuleName;
-    protected @Nullable
-    RNCWebViewClient mRNCWebViewClient;
-    protected @Nullable
-    CatalystInstance mCatalystInstance;
-    protected boolean sendContentSizeChangeEvents = false;
-    private OnScrollDispatchHelper mOnScrollDispatchHelper;
-    protected boolean hasScrollEvent = false;
-    protected boolean nestedScrollEnabled = false;
-    protected ProgressChangedFilter progressChangedFilter;
-
-    /**
-     * WebView must be created with an context of the current activity
-     * <p>
-     * Activity Context is required for creation of dialogs internally by WebView
-     * Reactive Native needed for access to ReactNative internal system functionality
-     */
-    public RNCWebView(ThemedReactContext reactContext) {
-      super(reactContext);
-      this.createCatalystInstance();
-      progressChangedFilter = new ProgressChangedFilter();
-    }
-
-    public void setIgnoreErrFailedForThisURL(String url) {
-      mRNCWebViewClient.setIgnoreErrFailedForThisURL(url);
-    }
-
-    public void setBasicAuthCredential(BasicAuthCredential credential) {
-      mRNCWebViewClient.setBasicAuthCredential(credential);
-    }
-
-    public void setSendContentSizeChangeEvents(boolean sendContentSizeChangeEvents) {
-      this.sendContentSizeChangeEvents = sendContentSizeChangeEvents;
-    }
-
-    public void setHasScrollEvent(boolean hasScrollEvent) {
-      this.hasScrollEvent = hasScrollEvent;
-    }
-
-    public void setNestedScrollEnabled(boolean nestedScrollEnabled) {
-      this.nestedScrollEnabled = nestedScrollEnabled;
-    }
-
-    @Override
-    public void onHostResume() {
-      // do nothing
-    }
-
-    @Override
-    public void onHostPause() {
-      // do nothing
-    }
-
-    @Override
-    public void onHostDestroy() {
-      cleanupCallbacksAndDestroy();
-    }
-
-    @Override
-    public boolean onTouchEvent(MotionEvent event) {
-      if (this.nestedScrollEnabled) {
-        requestDisallowInterceptTouchEvent(true);
-      }
-      return super.onTouchEvent(event);
-    }
-
-    @Override
-    protected void onSizeChanged(int w, int h, int ow, int oh) {
-      super.onSizeChanged(w, h, ow, oh);
-
-      if (sendContentSizeChangeEvents) {
-        dispatchEvent(
-          this,
-          new ContentSizeChangeEvent(
-            this.getId(),
-            w,
-            h
-          )
-        );
-      }
-    }
-
-    @Override
-    public void setWebViewClient(WebViewClient client) {
-      super.setWebViewClient(client);
-      if (client instanceof RNCWebViewClient) {
-        mRNCWebViewClient = (RNCWebViewClient) client;
-        mRNCWebViewClient.setProgressChangedFilter(progressChangedFilter);
-      }
-    }
-
-    WebChromeClient mWebChromeClient;
-    @Override
-    public void setWebChromeClient(WebChromeClient client) {
-      this.mWebChromeClient = client;
-      super.setWebChromeClient(client);
-      if (client instanceof RNCWebChromeClient) {
-        ((RNCWebChromeClient) client).setProgressChangedFilter(progressChangedFilter);
-      }
-    }
-
-    public @Nullable
-    RNCWebViewClient getRNCWebViewClient() {
-      return mRNCWebViewClient;
-    }
-
-    public void setInjectedJavaScript(@Nullable String js) {
-      injectedJS = js;
-    }
-
-    public void setInjectedJavaScriptBeforeContentLoaded(@Nullable String js) {
-      injectedJSBeforeContentLoaded = js;
-    }
-
-    public void setInjectedJavaScriptForMainFrameOnly(boolean enabled) {
-      injectedJavaScriptForMainFrameOnly = enabled;
-    }
-
-    public void setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(boolean enabled) {
-      injectedJavaScriptBeforeContentLoadedForMainFrameOnly = enabled;
-    }
-
-    protected RNCWebViewBridge createRNCWebViewBridge(RNCWebView webView) {
-      return new RNCWebViewBridge(webView);
-    }
-
-    protected void createCatalystInstance() {
-      ReactContext reactContext = (ReactContext) this.getContext();
-
-      if (reactContext != null) {
-        mCatalystInstance = reactContext.getCatalystInstance();
-      }
-    }
-
-    @SuppressLint("AddJavascriptInterface")
-    public void setMessagingEnabled(boolean enabled) {
-      if (messagingEnabled == enabled) {
-        return;
-      }
-
-      messagingEnabled = enabled;
-
-      if (enabled) {
-        addJavascriptInterface(createRNCWebViewBridge(this), JAVASCRIPT_INTERFACE);
-      } else {
-        removeJavascriptInterface(JAVASCRIPT_INTERFACE);
-      }
-    }
-
-    public void setMessagingModuleName(String moduleName) {
-      messagingModuleName = moduleName;
-    }
-
-    protected void evaluateJavascriptWithFallback(String script) {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-        evaluateJavascript(script, null);
-        return;
-      }
-
-      try {
-        loadUrl("javascript:" + URLEncoder.encode(script, "UTF-8"));
-      } catch (UnsupportedEncodingException e) {
-        // UTF-8 should always be supported
-        throw new RuntimeException(e);
-      }
-    }
-
-    public void callInjectedJavaScript() {
-      if (getSettings().getJavaScriptEnabled() &&
-        injectedJS != null &&
-        !TextUtils.isEmpty(injectedJS)) {
-        evaluateJavascriptWithFallback("(function() {\n" + injectedJS + ";\n})();");
-      }
-    }
-
-    public void callInjectedJavaScriptBeforeContentLoaded() {
-      if (getSettings().getJavaScriptEnabled() &&
-      injectedJSBeforeContentLoaded != null &&
-      !TextUtils.isEmpty(injectedJSBeforeContentLoaded)) {
-        evaluateJavascriptWithFallback("(function() {\n" + injectedJSBeforeContentLoaded + ";\n})();");
-      }
-    }
-
-    public void onMessage(String message) {
-      ReactContext reactContext = (ReactContext) this.getContext();
-      RNCWebView mContext = this;
-
-      if (mRNCWebViewClient != null) {
-        WebView webView = this;
-        webView.post(new Runnable() {
-          @Override
-          public void run() {
-            if (mRNCWebViewClient == null) {
-              return;
-            }
-            WritableMap data = mRNCWebViewClient.createWebViewEvent(webView, webView.getUrl());
-            data.putString("data", message);
-
-            if (mCatalystInstance != null) {
-              mContext.sendDirectMessage("onMessage", data);
-            } else {
-              dispatchEvent(webView, new TopMessageEvent(webView.getId(), data));
-            }
-          }
-        });
-      } else {
-        WritableMap eventData = Arguments.createMap();
-        eventData.putString("data", message);
-
-        if (mCatalystInstance != null) {
-          this.sendDirectMessage("onMessage", eventData);
-        } else {
-          dispatchEvent(this, new TopMessageEvent(this.getId(), eventData));
-        }
-      }
-    }
-
-    protected void sendDirectMessage(final String method, WritableMap data) {
-      WritableNativeMap event = new WritableNativeMap();
-      event.putMap("nativeEvent", data);
-
-      WritableNativeArray params = new WritableNativeArray();
-      params.pushMap(event);
-
-      mCatalystInstance.callFunction(messagingModuleName, method, params);
-    }
-
-    protected void onScrollChanged(int x, int y, int oldX, int oldY) {
-      super.onScrollChanged(x, y, oldX, oldY);
-
-      if (!hasScrollEvent) {
-        return;
-      }
-
-      if (mOnScrollDispatchHelper == null) {
-        mOnScrollDispatchHelper = new OnScrollDispatchHelper();
-      }
-
-      if (mOnScrollDispatchHelper.onScrollChanged(x, y)) {
-        ScrollEvent event = ScrollEvent.obtain(
-                this.getId(),
-                ScrollEventType.SCROLL,
-                x,
-                y,
-                mOnScrollDispatchHelper.getXFlingVelocity(),
-                mOnScrollDispatchHelper.getYFlingVelocity(),
-                this.computeHorizontalScrollRange(),
-                this.computeVerticalScrollRange(),
-                this.getWidth(),
-                this.getHeight());
-
-        dispatchEvent(this, event);
-      }
-    }
-
-    protected void dispatchEvent(WebView webView, Event event) {
-      ReactContext reactContext = (ReactContext) webView.getContext();
-      EventDispatcher eventDispatcher =
-        reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
-      eventDispatcher.dispatchEvent(event);
-    }
-
-    protected void cleanupCallbacksAndDestroy() {
-      setWebViewClient(null);
-      destroy();
-    }
-
-    @Override
-    public void destroy() {
-      if (mWebChromeClient != null) {
-        mWebChromeClient.onHideCustomView();
-      }
-      super.destroy();
-    }
-
-    protected class RNCWebViewBridge {
-      RNCWebView mContext;
-
-      RNCWebViewBridge(RNCWebView c) {
-        mContext = c;
-      }
-
-      /**
-       * This method is called whenever JavaScript running within the web view calls:
-       * - window[JAVASCRIPT_INTERFACE].postMessage
-       */
-      @JavascriptInterface
-      public void postMessage(String message) {
-        mContext.onMessage(message);
-      }
-    }
-
-    protected static class ProgressChangedFilter {
-      private boolean waitingForCommandLoadUrl = false;
-
-      public void setWaitingForCommandLoadUrl(boolean isWaiting) {
-        waitingForCommandLoadUrl = isWaiting;
-      }
-
-      public boolean isWaitingForCommandLoadUrl() {
-        return waitingForCommandLoadUrl;
-      }
     }
   }
 }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -139,9 +139,6 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
   public static final int COMMAND_LOAD_URL = 7;
   public static final int COMMAND_FOCUS = 8;
 
-  // commands added by Discord
-  public static final int COMMAND_RELEASE = 4001;
-
   // android commands
   public static final int COMMAND_CLEAR_FORM_DATA = 1000;
   public static final int COMMAND_CLEAR_CACHE = 1001;
@@ -167,6 +164,9 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
   protected @Nullable String mDownloadingMessage = null;
   protected @Nullable String mLackPermissionToDownloadMessage = null;
 
+  protected HashMap<String, WebView> keepedWebViewInstances = new HashMap<>();
+  protected ReactContext mReactContext;
+
   public RNCWebViewManager() {
     mWebViewConfig = new WebViewConfig() {
       public void configWebView(WebView webView) {
@@ -191,6 +191,8 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   protected RNCWebView createViewInstance(ThemedReactContext reactContext) {
     RNCWebView rncWebView = createRNCWebViewInstance(reactContext);
+
+    this.mReactContext = reactContext;
 
     // TODO: move setupWebChromeClient, configWebView, and WebSettings into RNCWebView.java
     setupWebChromeClient(reactContext, rncWebView);
@@ -532,6 +534,25 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
 
   @ReactProp(name = "source")
   public void setSource(RNCWebView view, @Nullable ReadableMap source) {
+    // そのように設定されている場合、初回の呼び出しは保持されている WebView インスタンスを利用する。
+    boolean initialized = view.isSourceInitialized();
+    view.markSourceInitialized();
+    RNCWebViewModule module = getModule(mReactContext);
+
+    if (view.configuredToKeepWebViewInstance() && !initialized && module.isWebViewInstancePreserved(view.getWebViewKey())) {
+      WebView webview = module.getPreservedWebViewInstance(view.getWebViewKey());
+      ViewGroup parent = (ViewGroup) webview.getParent();
+      if (parent != null) {
+        parent.removeView(webview);
+      }
+      view.setWebView(webview);
+      return;
+    }
+
+    if (view.configuredToKeepWebViewInstance()) {
+      module.preserveWebViewInstance(view.getWebViewKey(), view.getWebView());
+    }
+
     if (source != null) {
       if (source.hasKey("html")) {
         String html = source.getString("html");
@@ -680,6 +701,16 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
     view.getSettings().setMinimumFontSize(fontSize);
   }
 
+  @ReactProp(name = "keepWebViewInstanceAfterUnmount")
+  public void setKeepWebViewInstanceAfterUnmount(RNCWebView view, boolean keep) {
+    view.setKeepWebViewInstanceAfterUnmount(keep);
+  }
+
+  @ReactProp(name = "webViewKey")
+  public void setWebViewKey(RNCWebView view, String key) {
+    view.setWebViewKey(key);
+  }
+
   @Override
   protected void addEventEmitters(ThemedReactContext reactContext, RNCWebView view) {
     // Do not register default touch emitter and let WebView implementation handle touches
@@ -722,7 +753,6 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
       .put("clearFormData", COMMAND_CLEAR_FORM_DATA)
       .put("clearCache", COMMAND_CLEAR_CACHE)
       .put("clearHistory", COMMAND_CLEAR_HISTORY)
-      .put("release", COMMAND_RELEASE)
       .build();
   }
 
@@ -785,15 +815,21 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
       case "clearHistory":
         root.getWebView().clearHistory();
         break;
-      case "release":
-        // no-op for now
-        break;
     }
     super.receiveCommand(root, commandId, args);
   }
 
   @Override
   public void onDropViewInstance(RNCWebView rncWebView) {
+    RNCWebViewModule module = getModule(mReactContext);
+    if (rncWebView.configuredToKeepWebViewInstance() && module.isWebViewInstancePreserved(rncWebView.getWebViewKey())) {
+      WebView preservedInstance = module.getPreservedWebViewInstance(rncWebView.getWebViewKey());
+      if (preservedInstance == rncWebView.getWebView()) {
+        // WebView インスタンスが保持される設定だった場合、onDrop の各種処理をスキップする
+        return;
+      }
+    }
+
     super.onDropViewInstance(rncWebView);
     ((ThemedReactContext) rncWebView.getContext()).removeLifecycleEventListener(rncWebView);
     rncWebView.cleanupCallbacksAndDestroy();

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -533,6 +533,8 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
 
   @ReactProp(name = "source")
   public void setSource(RNCWebView view, @Nullable ReadableMap source) {
+    RNCWebViewModule module = getModule(mReactContext);
+
     // WebView インスタンスを使い回すようオプションが設定されている場合
     if (view.configuredToKeepWebViewInstance()) {
       // 初回の setSource 呼び出しで、かつ保持されている WebView インスタンスが既にある場合は、それを利用する。loadUrl() などは呼び出さない

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -164,7 +164,6 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
   protected @Nullable String mDownloadingMessage = null;
   protected @Nullable String mLackPermissionToDownloadMessage = null;
 
-  protected HashMap<String, WebView> keepedWebViewInstances = new HashMap<>();
   protected ReactContext mReactContext;
 
   public RNCWebViewManager() {

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -23,6 +23,7 @@ import android.webkit.MimeTypeMap;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.widget.Toast;
+import android.webkit.WebView;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Promise;
@@ -53,6 +54,7 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
   private File outputImage;
   private File outputVideo;
   private DownloadManager.Request downloadRequest;
+  private HashMap<String, WebView> preservedWebViewInstances = new HashMap<>();
 
   protected static class ShouldOverrideUrlLoadingLock {
     protected enum ShouldOverrideCallbackState {
@@ -149,6 +151,33 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
         lockObject.notify();
       }
     }
+  }
+
+  public void preserveWebViewInstance(String key, WebView view) {
+    this.preservedWebViewInstances.put(key, view);
+  }
+
+  public WebView getPreservedWebViewInstance(String key) {
+    return this.preservedWebViewInstances.get(key);
+  }
+
+  public boolean isWebViewInstancePreserved(String key) {
+    return this.preservedWebViewInstances.containsKey(key);
+  }
+
+  @ReactMethod
+  public void isWebViewInstancePreserved(String key, Promise promise) {
+    promise.resolve(this.preservedWebViewInstances.containsKey(key));
+  }
+
+  @ReactMethod
+  public void releasePreservedWebViewInstance(String key) {
+    this.preservedWebViewInstances.remove(key);
+  }
+
+  @ReactMethod
+  public void clearPreservedWebViewInstances() {
+    this.preservedWebViewInstances.clear();
   }
 
   public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -20,6 +20,7 @@ import LocalPageLoad from './examples/LocalPageLoad';
 import Messaging from './examples/Messaging';
 import NativeWebpage from './examples/NativeWebpage';
 import ApplePay from './examples/ApplePay';
+import Portals from './examples/Portals';
 
 const TESTS = {
   Messaging: {
@@ -101,7 +102,15 @@ const TESTS = {
     render() {
       return <ApplePay />;
     },
-  }
+  },
+  Portals: {
+    title: 'Portals',
+    testId: 'Portals',
+    description: 'Test teleporting a child view between two parent views',
+    render() {
+      return <Portals />;
+    },
+  },
 };
 
 type Props = {};
@@ -196,6 +205,11 @@ export default class App extends Component<Props, State> {
                   onPress={() => this._changeTest('ApplePay')}
               />
           )}
+          <Button
+            testID="testType_portals"
+            title="Portals"
+            onPress={() => this._changeTest('Portals')}
+          />
         </View>
 
         {restarting ? null : (

--- a/example/examples/Portals.tsx
+++ b/example/examples/Portals.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import {View, Button} from 'react-native';
 import PortalGate from '../portals/PortalGate';
 import PortalProvider from '../portals/PortalProvider';
-
-import WebView from 'react-native-webview';
+import WebView, { releaseWebView, clearWebViews } from 'react-native-webview';
 import { PortalContext } from '../portals/PortalContext';
 
 const IFRAME_URI = 'https://www.usaswimming.org';
@@ -11,6 +10,8 @@ const BLUE_GATE_NAME = 'blueGate';
 const GREEN_GATE_NAME = 'greenGate';
 const WEB_VIEW_KEY = 'PortalTestingWebViewKey'
 const IFRAME_WIDTH = 360;
+const PORTALS_PAGE = 0;
+const NONPORTALS_PAGE = 1;
 
 const source = {
   html: `
@@ -29,15 +30,34 @@ const source = {
 };
 
 export default function Portals() {
+  const [pageNumber, setPageNumber] = React.useState(PORTALS_PAGE);
+
+  const togglePages = () => {
+    const nextPage = pageNumber === PORTALS_PAGE ? NONPORTALS_PAGE : PORTALS_PAGE;
+    setPageNumber(nextPage);
+  }
+
   return (
-    <PortalProvider>
-      <PortalGates/>
-    </PortalProvider>
+    <>
+      <Button
+        title="Toggle Pages"
+        onPress={togglePages}
+      />
+      {pageNumber === PORTALS_PAGE ? (
+        <PortalProvider>
+          <PortalGatesPage />
+        </PortalProvider>
+      ) : null}
+      {pageNumber === NONPORTALS_PAGE ? (
+        <NonPortalsPage />
+      ) : null}
+    </>
+
   )
 }
 
-function PortalGates() {
-  const {gates, teleport} = React.useContext(PortalContext);
+function PortalGatesPage() {
+  const { gates, teleport } = React.useContext(PortalContext);
 
   const [releaseCounter, setReleaseCounter] = React.useState(0);
 
@@ -68,7 +88,11 @@ function PortalGates() {
     teleport(gates, GREEN_GATE_NAME, undefined);
     teleport(gates, BLUE_GATE_NAME, undefined);
     setReleaseCounter(releaseCounter + 1);
-    webViewRef.current?.release();
+    releaseWebView(WEB_VIEW_KEY);
+  }, []);
+
+  React.useEffect(() => {
+    teleportToBlueGate();
   }, []);
 
   return (
@@ -85,6 +109,10 @@ function PortalGates() {
         title="Release WebView"
         onPress={release}
       />
+      <Button
+        title="Clear all WebViews"
+        onPress={() => { clearWebViews() }}
+      />
       <View style={{width: IFRAME_WIDTH, height: 160, backgroundColor: 'blue', marginBottom: 32}}>
         <PortalGate gateName={BLUE_GATE_NAME}/>
       </View>
@@ -93,4 +121,17 @@ function PortalGates() {
       </View>
     </>
   )
+}
+
+function NonPortalsPage() {
+  const release = () => {
+    releaseWebView(WEB_VIEW_KEY);
+  };
+
+  return (
+    <Button
+      title="Release WebView"
+      onPress={release}
+    />
+  );
 }

--- a/example/examples/Portals.tsx
+++ b/example/examples/Portals.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import {View, Button} from 'react-native';
+import PortalGate from '../portals/PortalGate';
+import PortalProvider from '../portals/PortalProvider';
+
+import WebView from 'react-native-webview';
+import { PortalContext } from '../portals/PortalContext';
+
+const IFRAME_URI = 'https://www.usaswimming.org';
+const BLUE_GATE_NAME = 'blueGate';
+const GREEN_GATE_NAME = 'greenGate';
+const WEB_VIEW_KEY = 'PortalTestingWebViewKey'
+const IFRAME_WIDTH = 360;
+
+const source = {
+  html: `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>iframe test</title>
+      </head>
+      <body>
+       <iframe src="${IFRAME_URI}" name="iframe_0" style="width: ${IFRAME_WIDTH}px; height: 500px;"></iframe>
+      </body>
+    </html>
+`,
+};
+
+export default function Portals() {
+  return (
+    <PortalProvider>
+      <PortalGates/>
+    </PortalProvider>
+  )
+}
+
+function PortalGates() {
+  const {gates, teleport} = React.useContext(PortalContext);
+
+  const [releaseCounter, setReleaseCounter] = React.useState(0);
+
+  const webViewRef = React.useRef<WebView>(null);
+
+  const webView = React.useMemo(() => {
+    return (
+      <WebView
+          source={source}
+          webViewKey={WEB_VIEW_KEY}
+          keepWebViewInstanceAfterUnmount
+          ref={webViewRef}
+        />
+    );
+  }, [releaseCounter]);
+
+  const teleportToBlueGate = React.useCallback(() => {
+    teleport(gates, GREEN_GATE_NAME, undefined);
+    teleport(gates, BLUE_GATE_NAME, webView);
+  }, [teleport, webView]);
+
+  const teleportToGreenGate = React.useCallback(() => {
+    teleport(gates, BLUE_GATE_NAME, undefined);
+    teleport(gates, GREEN_GATE_NAME, webView);
+  }, [teleport, webView])
+
+  const release = React.useCallback(() => {
+    teleport(gates, GREEN_GATE_NAME, undefined);
+    teleport(gates, BLUE_GATE_NAME, undefined);
+    setReleaseCounter(releaseCounter + 1);
+    webViewRef.current?.release();
+  }, []);
+
+  return (
+    <>
+      <Button
+        title="Teleport to blue gate"
+        onPress={teleportToBlueGate}
+      />
+      <Button
+        title="Teleport to green gate"
+        onPress={teleportToGreenGate}
+      />
+      <Button
+        title="Release WebView"
+        onPress={release}
+      />
+      <View style={{width: IFRAME_WIDTH, height: 160, backgroundColor: 'blue', marginBottom: 32}}>
+        <PortalGate gateName={BLUE_GATE_NAME}/>
+      </View>
+      <View style={{width: IFRAME_WIDTH, height: 200, backgroundColor: 'green'}}>
+        <PortalGate gateName={GREEN_GATE_NAME}/>
+      </View>
+    </>
+  )
+}

--- a/example/portals/PortalContext.tsx
+++ b/example/portals/PortalContext.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+export const PortalContext = React.createContext<IPortalContext>({
+  gates: new Map(),
+  teleport: (_gates: Map<string, React.ReactNode | undefined>, _gateName: string, _node: React.ReactNode) => {}
+})
+interface IPortalContext {
+  gates: Map<string, React.ReactNode | undefined>,
+  teleport: (gates: Map<string, React.ReactNode | undefined>, gateName: string, node: React.ReactNode) => void;
+}

--- a/example/portals/PortalGate.tsx
+++ b/example/portals/PortalGate.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import {PortalContext} from './PortalContext';
+
+interface PortalGateProps {
+  gateName: string;
+}
+
+export default function PortalGate({gateName}: PortalGateProps) {
+  const {gates} = React.useContext(PortalContext);
+
+  return <React.Fragment>{gates.get(gateName)}</React.Fragment>;
+}

--- a/example/portals/PortalProvider.tsx
+++ b/example/portals/PortalProvider.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import {PortalContext} from './PortalContext';
+
+interface PortalProviderProps {
+  children: React.ReactNode;
+}
+
+export default function PortalProvider({children}: PortalProviderProps) {
+  const [gates, setGates] = React.useState(new Map());
+
+  const teleport = React.useCallback(
+    (gates: Map<string, React.ReactNode | undefined>, gateName: string, node: React.ReactNode) => {
+      const newGates = new Map(gates.set(gateName, node));
+      setGates(newGates);
+    },
+    []
+  );
+
+  return <PortalContext.Provider value={{gates, teleport}}>{children}</PortalContext.Provider>;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -59,13 +59,9 @@ declare class WebView<P = {}> extends Component<WebViewProps & P> {
      * Tells this WebView to clear its internal back/forward list.
      */
     clearHistory?: () => void;
-
-    /**
-     * Explicitly release the native WebView instance if it hasn't released after the React
-     * component unmounts;
-     */
-    release: () => void;
 }
 
 export {WebView};
 export default WebView;
+
+export { releaseWebView, clearWebViews } from './lib/utilityMethods';

--- a/index.d.ts
+++ b/index.d.ts
@@ -59,6 +59,12 @@ declare class WebView<P = {}> extends Component<WebViewProps & P> {
      * Tells this WebView to clear its internal back/forward list.
      */
     clearHistory?: () => void;
+
+    /**
+     * Explicitly release the native WebView instance if it hasn't released after the React
+     * component unmounts;
+     */
+    release: () => void;
 }
 
 export {WebView};

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import WebView from './lib/WebView';
+import { releaseWebView, clearWebViews } from './lib/utilityMethods';
 
-export { WebView };
+export { WebView, releaseWebView, clearWebViews };
 export default WebView;

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -30,7 +30,7 @@ import styles from './WebView.styles';
 const codegenNativeCommands = codegenNativeCommandsUntyped as <T extends {}>(options: { supportedCommands: (keyof T)[] }) => T;
 
 const Commands = codegenNativeCommands({
-  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', 'injectJavaScript', 'requestFocus', 'postMessage', 'clearFormData', 'clearCache', 'clearHistory', 'loadUrl', 'release'],
+  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', 'injectJavaScript', 'requestFocus', 'postMessage', 'clearFormData', 'clearCache', 'clearHistory', 'loadUrl'],
 });
 
 const { resolveAssetSource } = Image;
@@ -119,7 +119,6 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     clearFormData: () => Commands.clearFormData(webViewRef.current),
     clearCache: (includeDiskFiles: boolean) => Commands.clearCache(webViewRef.current, includeDiskFiles),
     clearHistory: () => Commands.clearHistory(webViewRef.current),
-    release: () => Commands.release(webViewRef.current),
   }), [setViewState, webViewRef]);
 
   const directEventCallbacks = useMemo(() => ({

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -30,7 +30,7 @@ import styles from './WebView.styles';
 const codegenNativeCommands = codegenNativeCommandsUntyped as <T extends {}>(options: { supportedCommands: (keyof T)[] }) => T;
 
 const Commands = codegenNativeCommands({
-  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', 'injectJavaScript', 'requestFocus', 'postMessage', 'clearFormData', 'clearCache', 'clearHistory', 'loadUrl'],
+  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', 'injectJavaScript', 'requestFocus', 'postMessage', 'clearFormData', 'clearCache', 'clearHistory', 'loadUrl', 'release'],
 });
 
 const { resolveAssetSource } = Image;
@@ -119,6 +119,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     clearFormData: () => Commands.clearFormData(webViewRef.current),
     clearCache: (includeDiskFiles: boolean) => Commands.clearCache(webViewRef.current, includeDiskFiles),
     clearHistory: () => Commands.clearHistory(webViewRef.current),
+    release: () => Commands.release(webViewRef.current),
   }), [setViewState, webViewRef]);
 
   const directEventCallbacks = useMemo(() => ({

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -20,8 +20,7 @@ type WebViewCommands =
   | 'postMessage'
   | 'injectJavaScript'
   | 'loadUrl'
-  | 'requestFocus'
-  | 'release';
+  | 'requestFocus';
 
 type AndroidWebViewCommands = 'clearHistory' | 'clearCache' | 'clearFormData';
 
@@ -341,6 +340,8 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   minimumFontSize?: number;
   downloadingMessage?: string;
   lackPermissionToDownloadMessage?: string;
+  keepWebViewInstanceAfterUnmount?: boolean;
+  webViewKey?: string;
 }
 
 export declare type ContentInsetAdjustmentBehavior =
@@ -1118,6 +1119,27 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * @platform android
    */
   lackPermissionToDownloadMessage?: string;
+
+  /**
+   * By default, if this is undefined or false, the native WebView will get released when
+   * the React component unmounts.
+   *
+   * When this is true, the native WebView will not get released when the React component
+   * unmounts. When a React component remounts, it can use a previous native WebView instance
+   * by using the same webViewKey prop that the previous React component used.
+   *
+   * It's important to call `release` on the React WebView with the corresponding webViewKey
+   * when the native WebView is no longer needed.
+   * @platform android
+   */
+  keepWebViewInstanceAfterUnmount?: boolean;
+
+  /**
+   * When keepWebViewInstanceAfterUnmount is true, if two React components use the same
+   * key for the WebView, they will use the same native WebView instance.
+   * @platform android
+   */
+  webViewKey?: string;
 }
 
 export interface WebViewSharedProps extends ViewProps {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -20,7 +20,8 @@ type WebViewCommands =
   | 'postMessage'
   | 'injectJavaScript'
   | 'loadUrl'
-  | 'requestFocus';
+  | 'requestFocus'
+  | 'release';
 
 type AndroidWebViewCommands = 'clearHistory' | 'clearCache' | 'clearFormData';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import WebView from './WebView';
+import { releaseWebView, clearWebViews } from './utilityMethods';
 
-export { WebView };
+export { WebView, releaseWebView, clearWebViews };
 export default WebView;

--- a/src/utilityMethods.android.tsx
+++ b/src/utilityMethods.android.tsx
@@ -1,0 +1,11 @@
+import { NativeModules } from 'react-native';
+
+const releaseWebView = function releaseWebView(webViewKey: string) {
+    NativeModules.RNCWebView.releasePreservedWebViewInstance(webViewKey);
+}
+
+const clearWebViews = function clearWebViews() {
+    NativeModules.RNCWebView.clearPreservedWebViewInstances();
+}
+
+export { releaseWebView, clearWebViews };

--- a/src/utilityMethods.ios.tsx
+++ b/src/utilityMethods.ios.tsx
@@ -1,0 +1,8 @@
+/* eslint-disable no-unused-vars */
+export function releaseWebView(_webViewKey: string) {
+    // no-op
+}
+
+export function clearWebViews() {
+    // no-op
+}

--- a/src/utilityMethods.macos.tsx
+++ b/src/utilityMethods.macos.tsx
@@ -1,0 +1,8 @@
+/* eslint-disable no-unused-vars */
+export function releaseWebView(_webViewKey: string) {
+    // no-op
+}
+
+export function clearWebViews() {
+    // no-op
+}

--- a/src/utilityMethods.tsx
+++ b/src/utilityMethods.tsx
@@ -1,0 +1,8 @@
+/* eslint-disable no-unused-vars */
+export function releaseWebView(_webViewKey: string) {
+    // no-op
+}
+
+export function clearWebViews() {
+    // no-op
+}

--- a/src/utilityMethods.windows.tsx
+++ b/src/utilityMethods.windows.tsx
@@ -1,0 +1,8 @@
+/* eslint-disable no-unused-vars */
+export function releaseWebView(_webViewKey: string) {
+    // no-op
+}
+
+export function clearWebViews() {
+    // no-op
+}


### PR DESCRIPTION
ref. https://github.com/ReactCorp/Cocalero_mvp/issues/4713

https://github.com/ReactCorp/Cocalero_mvp/issues/4713#issuecomment-1217647590 でアドバイスいただいた react-native-webview 側で WebView インスタンスを保持する方針の差分です。

こちらを利用した cocalero-client-for-android 側の差分は https://github.com/ReactCorp/cocalero-client-for-android/pull/1651 です。

# やったこと

https://github.com/discord/react-native-webview/pull/2 ( https://github.com/react-native-webview/react-native-webview/pull/2469#issue-1225548281 ) をベースに Android 側でインスタンスを保持する処理を追加しました。

- https://github.com/discord/react-native-webview/pull/2 について
    - こちら (とそのベースになっている https://github.com/discord/react-native-webview/pull/1 ) は react-native-webview に WebView インスタンスを保持する機能を追加したもの
        - `keepWebViewInstanceAfterUnmount` と `webViewKey` というオプションが追加されている
    - iOS 側のみで、Android は途中までしか実装されていない
    - Android 側は実装に必要な前段階のリファクタまで終わっている
        - 具体的には RNCWebViewManager が WebView を直接継承しているのをやめ、RNCWebView を経由して WebView を保持するように変更されている
        - https://github.com/react-native-webview/react-native-webview/pull/2469#issue-1225548281 の `Proposed Future Android Changes:` も一読いただけるとわかりやすいと思います
- [22ef8af](https://github.com/ReactCorp/react-native-webview/pull/1/commits/22ef8af14fece61b57847d41791772c1b2c06285)
    - https://github.com/discord/react-native-webview/pull/2 は v11.18.1 をベースにしているので、v11.23.0 (現時点の最新) に対して改めて https://github.com/discord/react-native-webview/pull/2 の内容を当てました
    - ただし iOS 側の差分は取り込んでいません
- [df6b631](https://github.com/ReactCorp/react-native-webview/pull/1/commits/df6b631120f0759be1526d0829a9427927717b93)
    - 実際に Android 側でインスタンスを保持する実装です
    - iOS 実装とは以下の差異があります
        - インスタンスを生成したりキープするタイミング
            - https://github.com/react-native-webview/react-native-webview/pull/2469#issue-1225548281 では `onAttachedToWindow` で WebView インスタンスを生成したい (そのために kotlin に書き換えたい) と discord エンジニアの展望が書かれているのですが、この方針で行くと大変そうだったので、簡単に [setSource](https://github.com/ReactCorp/react-native-webview/pull/1/commits/d553cf7b2e727ea272f5c568b92c7077b084cc08#diff-e9700631fc9fa5600d2e1ee70eb2d28aa2a1fbc695b85f99981972d3904ca485R534) と [onDropViewInstance](https://github.com/ReactCorp/react-native-webview/pull/1/commits/d553cf7b2e727ea272f5c568b92c7077b084cc08#diff-e9700631fc9fa5600d2e1ee70eb2d28aa2a1fbc695b85f99981972d3904ca485R796) でこの辺を調整するようにしています
        - 保持したインスタンスの破棄方法
            - iOS 側はその後の pr で [インスタンスメソッドではなく static メソッドで破棄処理が実装された](https://github.com/discord/react-native-webview/pull/4) ので、それに合わせています
        - discord 版にはないユーティリティを追加
            - [clearWebViews](https://github.com/ReactCorp/react-native-webview/pull/1/commits/df6b631120f0759be1526d0829a9427927717b93#diff-f8b6d8723f49f125b655c30c42353a5e528668936915d0b90cd774b8bc7a9669R178-R181) という保持したインスタンスをすべて破棄するメソッド
                - 状態をクリアするのに手っ取り早いため一旦こうしました。最終的に discord 版が本家にマージされると使えなくなるかもしれませんが、その場合は名前を指定して破棄すればよいだけなので、大丈夫かなと思っています
            - [isWebViewInstancePreserved](https://github.com/ReactCorp/react-native-webview/pull/1/commits/df6b631120f0759be1526d0829a9427927717b93#diff-f8b6d8723f49f125b655c30c42353a5e528668936915d0b90cd774b8bc7a9669R168-R171) というそのキーのインスタンスがあるかを確認するメソッド

# 懸念点

- 今後の react-native-webview の変更に対して、メンテナンスが追いついていけるか
    - discord の [本家への pr](https://github.com/react-native-webview/react-native-webview/pull/2469#issue-1225548281) がマージされればベストなのだが、今の所その気配が無い
        - レビュー通過後この差分も本家にフィードバックして援護射撃はしようと思っています
    - 前述のように https://github.com/discord/react-native-webview/pull/2 にてクラス継承関係の変更が入っているので、本家側が discord の提案を取り込む気が無いと、追従していくのがちょっと大変かもしれない
    - 逆に RN 側のメンテナンス性にはメリットがあると思っています
- そもそもの Java, Android 自体の知識も乏しいので、ツッコミどころがあれば是非mm
    - インスタンスを保持する位置や生成・破棄タイミングなど