### PR TITLE
イベント受け渡しの修正

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -546,6 +546,10 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
         }
         view.setWebView(webview);
         view.markSourceInitialized();
+
+        String url = source.getString("uri");
+        view.getRNCWebViewClient().emitFinishEvent(view.getWebView(), url);
+
         return;
       } else {
         // そうでない場合はインスタンスを保持し、loadUrl() などの以降の処理も行う
@@ -987,7 +991,7 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
       this.rncWebView.dispatchEvent(
         webView,
         new TopLoadingStartEvent(
-          webView.getId(),
+          this.rncWebView.getId(),
           createWebViewEvent(webView, url)));
     }
 
@@ -1034,7 +1038,7 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
         this.rncWebView.dispatchEvent(
           view,
           new TopShouldStartLoadWithRequestEvent(
-            view.getId(),
+            this.rncWebView.getId(),
             createWebViewEvent(view, url)));
         return true;
       }
@@ -1149,7 +1153,7 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
 
       this.rncWebView.dispatchEvent(
         webView,
-        new TopLoadingErrorEvent(webView.getId(), eventData));
+        new TopLoadingErrorEvent(this.rncWebView.getId(), eventData));
     }
 
     @RequiresApi(api = Build.VERSION_CODES.M)
@@ -1167,7 +1171,7 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
 
         this.rncWebView.dispatchEvent(
           webView,
-          new TopHttpErrorEvent(webView.getId(), eventData));
+          new TopHttpErrorEvent(this.rncWebView.getId(), eventData));
       }
     }
 
@@ -1199,7 +1203,7 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
 
       this.rncWebView.dispatchEvent(
           webView,
-          new TopRenderProcessGoneEvent(webView.getId(), event)
+          new TopRenderProcessGoneEvent(this.rncWebView.getId(), event)
         );
 
         // returning false would crash the app.
@@ -1210,7 +1214,7 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
       this.rncWebView.dispatchEvent(
         webView,
         new TopLoadingFinishEvent(
-          webView.getId(),
+          this.rncWebView.getId(),
           createWebViewEvent(webView, url)));
     }
 
@@ -1324,7 +1328,7 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
       this.mRncWebView.dispatchEvent(
         webView,
         new TopLoadingProgressEvent(
-          webView.getId(),
+          this.mRncWebView.getId(),
           event));
     }
 

--- a/example/examples/Portals.tsx
+++ b/example/examples/Portals.tsx
@@ -70,6 +70,11 @@ function PortalGatesPage() {
           webViewKey={WEB_VIEW_KEY}
           keepWebViewInstanceAfterUnmount
           ref={webViewRef}
+          startInLoadingState
+          onLoad={() => { console.log("onLoad") }}
+          onLoadEnd={() => { console.log("onLoadEnd") }}
+          onLoadStart={() => { console.log("onLoadStart") }}
+          onLoadProgress={() => { console.log("onLoadProgress") }}
         />
     );
   }, [releaseCounter]);


### PR DESCRIPTION
ref. https://github.com/ReactCorp/Cocalero_mvp/issues/4713#issuecomment-1246152256

[startInLoadingState](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#startinloadingstate) オプションがうまく動作していなかったので修正しました。

具体的にはネイティブから RN へのイベント発火の際に、(WebView ではなく) RNCWebView の id を渡すようにしました。あとから気づいたのですが discord が本家に出した pr の [最新版でも同じ修正がされていました](https://github.com/react-native-webview/react-native-webview/pull/2469/files#diff-e9700631fc9fa5600d2e1ee70eb2d28aa2a1fbc695b85f99981972d3904ca485R1021)。

背景はすこし込み入っていているのですが、詳しくは https://github.com/ReactCorp/Cocalero_mvp/issues/4713#issuecomment-1246152256 も参考ください。

## 動作確認

- [x] react-native-webview 付属のテストアプリにて startinloadingstate オプションを有効化し意図通り動作すること

https://user-images.githubusercontent.com/25668/190351955-ef909635-9b10-45b2-8735-9d7257f86306.mp4

- [x] cocalero-client-for-android にて
    - [x] startinloadingstate が有効な WebView (お知らせやコンテンツのヘルプ) が表示されること
    - [x] webgame を最小化しても状態が維持されること

https://user-images.githubusercontent.com/25668/190352143-df6a95d1-f231-41e5-851c-d0716a020c1d.mp4


