### PR TITLE
ディスク上のリソースキャッシュは残す

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -169,7 +169,7 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
             webview.stopLoading();
             // js
             webview.clearHistory();
-            webview.clearCache(true);
+            webview.clearCache(false);
             webview.clearFormData();
             // parent
             ViewGroup parent = (ViewGroup) webview.getParent();


### PR DESCRIPTION
ref. https://github.com/ReactCorp/Cocalero_mvp/issues/6120

issueに詳細を記載しましたが、特にバージョン6.13.0からWebViewを使用するゲームでは、ゲーム起動のたびに全リソースファイルをサーバーへリクエストして取得するようになっていました。特にインターネット接続が遅い場合、ゲーム起動に毎回時間がかかりUXの低下につながりますし、ユーザーやサーバーの帯域にも負担をかかります。

またゲームサーバー（Google Cloud Storage）では、全リソースファイルに7日間のCache-Controlが設定されており、できるだけその設定に従って動作するようにしたいと考えています。


行った修正は、v6.13.0で入った修正

* https://github.com/ReactCorp/react-native-webview/pull/5

を微調整し、ディスク上にキャッシュが残るようにしました。このPRで対応した問題への影響は不確かですが、メモリ上のキャッシュはクリアするようにしたため、WebViewが残り続ける現象には影響しないと考えています。

* [react-native-webview/docs/Reference.md at master · ReactCorp/react-native-webview](https://github.com/ReactCorp/react-native-webview/blob/master/docs/Reference.md#clearcachebool)
* [WebView  |  Android Developers](https://developer.android.com/reference/android/webkit/WebView.html#clearCache(boolean))

  > if false, only the RAM cache is cleared

手元で

* Cache-Controlが設定されたリソースに対しては、2回目以降のリクエストが行われないこと。
* 複数人で「してそ〜診断」（音が鳴り続けるコンテンツ）をプレイしても、音が残る現象が現時点では発生していないこと。

を確認しました。

---
issueにも書きましたが、[UnityWebGL.wasm.unitywebのキャッシュになぜか失敗する現象](https://github.com/ReactCorp/Cocalero_mvp/issues/6120#issuecomment-1879619799)は解消していません。これはUnityまたはChromeでの解決が必要な問題と認識しています。




