### PR TITLE
Suppress _jsxFileName output

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ci": "CI=true && yarn lint",
     "ci:publish": "yarn semantic-release",
     "lint": "yarn tsc --noEmit && yarn eslint ./src --ext .ts,.tsx,.js,.jsx",
-    "build": "babel --extensions \".ts,.tsx\" --out-dir lib src",
+    "build": "NODE_ENV=production babel --extensions \".ts,.tsx\" --out-dir lib src",
     "prepare:types": "tsc --noEmit false --emitDeclarationOnly --declaration --rootDir src --outDir lib",
     "prepare": "yarn prepare:types && yarn build",
     "appium": "appium",


### PR DESCRIPTION
ref. https://github.com/ReactCorp/cocalero-client-for-android/pull/2903

- NODE_ENVが空の場合: `_jsxFileName`が埋め込まれる
    - [WebView.android.js](https://github.com/user-attachments/files/18729291/WebView.android.js.txt)
- NODE_ENVがproductionの場合: `_jsxFileName`が埋め込まれない
    - [WebView.android.js](https://github.com/user-attachments/files/18729310/WebView.android.js.txt)
