### PR TITLE
Revert "enable web debugging in internal test"

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -6,7 +6,6 @@ import android.app.Activity;
 import android.app.DownloadManager;
 import android.content.Context;
 import android.content.pm.ActivityInfo;
-import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.Color;
@@ -217,7 +216,7 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
       new LayoutParams(LayoutParams.MATCH_PARENT,
         LayoutParams.MATCH_PARENT));
 
-    if ((ReactBuildConfig.DEBUG || ApplicationInfo.FLAG_DEBUGGABLE != 0) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+    if (ReactBuildConfig.DEBUG && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
       WebView.setWebContentsDebuggingEnabled(true);
     }
 


### PR DESCRIPTION
Reverts ReactCorp/react-native-webview#8
ref. https://github.com/ReactCorp/Cocalero_mvp/issues/7752

`WebView.setWebContentsDebuggingEnabled(true)` がリリースビルドでも呼ばれているので修正。
`ApplicationInfo.FLAG_DEBUGGABLE` は常に 2 で毎回条件が true になっているため。

> Constant Value: 2 (0x00000002)
> https://developer.android.com/reference/android/content/pm/ApplicationInfo#FLAG_DEBUGGABLE

もともとやりたかった `webgameのweb debug(console)をstagingでも見れるようにする`は、別のアプローチを
試そうと思っているのでこの PR ではいったん以前に戻す。